### PR TITLE
Update; fix the examples to point to correct CSS

### DIFF
--- a/examples/buttons/index.html
+++ b/examples/buttons/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>ClientKit Demos</title>
-  <link rel="stylesheet" href="../.dist/clientkit.css">
+  <link rel="stylesheet" href="../../.dist/clientkit.css">
   <style>
     header, main, footer {
       width: 1024px;

--- a/examples/tabs/index.html
+++ b/examples/tabs/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge,chrome=1" />
     <!-- iphone meta tag (width=device-width letterboxes on iphone 5) -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="../../.dist/tabs.css" />
+    <link rel="stylesheet" href="../.dist/tabs.css" />
     <title>Tabs Example</title>
   </head>
   <body>

--- a/examples/tabs/index.html
+++ b/examples/tabs/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge,chrome=1" />
     <!-- iphone meta tag (width=device-width letterboxes on iphone 5) -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="../.dist/tabs.css" />
+    <link rel="stylesheet" href="../../.dist/tabs.css" />
     <title>Tabs Example</title>
   </head>
   <body>


### PR DESCRIPTION
Why is this pull request necessary:

The examples directory was changed to add another depth of folder, and thus the CSS was broken since it wasn't changed to reflect.

Changes proposed in this pull request:

- update buttons example
- update tabs example