### PR TITLE
refactor button

### DIFF
--- a/conf/default-colors.yaml
+++ b/conf/default-colors.yaml
@@ -14,6 +14,3 @@ color:
   input-border: '#333'
   button-primary-bg: 'rgba(75, 157, 249, 1)'
   button-primary-color: '{{color.white}}'
-  button-secondary-bg: '{{color.primary}}'
-  button-secondary-color: '{{color.white}}'
-  button-primary-outline-color: '{{color["button-primary-color"]}}'

--- a/examples/buttons/index.html
+++ b/examples/buttons/index.html
@@ -20,7 +20,6 @@
       <h1>Buttons</h1>
       <h2 class="heading-3">Default Buttons</h2>
       <button class="button" type="button">Primary</button>
-      <button class="btn btn-secondary" type="button">Secondary</button>
       <h2 class="heading-3">Outline Buttons</h2>
       <button class="button-outline" type="button">Primary</button>
     </section>

--- a/examples/buttons/index.html
+++ b/examples/buttons/index.html
@@ -19,10 +19,10 @@
     <section class="buttons">
       <h1>Buttons</h1>
       <h2 class="heading-3">Default Buttons</h2>
-      <button class="btn btn-primary" type="button">Primary</button>
+      <button class="button" type="button">Primary</button>
       <button class="btn btn-secondary" type="button">Secondary</button>
       <h2 class="heading-3">Outline Buttons</h2>
-      <button class="btn btn-primary-outline" type="button">Primary</button>
+      <button class="button-outline" type="button">Primary</button>
     </section>
   </main>
   <footer>

--- a/styles/helpers/buttons.css
+++ b/styles/helpers/buttons.css
@@ -1,20 +1,7 @@
-.btn {
-  display: inline-block;
-  line-height: 1;
-  text-align: center;
-  font-size: 14px;
-  padding: 12px 14px;
-  border: 1px solid transparent;
-  border-radius: 3px;
-  vertical-align: middle;
-  cursor: pointer;
-}
-.btn-primary {
+.button {
   @mixin button var(--color-button-primary-bg), var(--color-button-primary-color);
 }
-.btn-secondary {
-  @mixin button var(--color-button-secondary-bg), var(--color-button-secondary-color);
-}
-.btn-primary-outline {
-  @mixin button-outline var(--color-button-primary-outline-color);
+
+.button-outline {
+  @mixin button var(--color-button-primary-bg), var(--color-button-primary-color), outline;
 }

--- a/styles/mixins/button.js
+++ b/styles/mixins/button.js
@@ -1,15 +1,42 @@
+'use strict';
 module.exports = function () {
-  return function (mixin, bgColor, color) {
-    const activeBgColor = 'red';
-    const styles = {};
-    const state = {
-      'background-color': activeBgColor
-    };
-    styles['background-color'] = bgColor;
-    styles.color = color;
+  return function (mixin, bgColor, fgColor, type) {
+
+    const styles = {
+      display: 'inline-block',
+      'line-height': 1,
+      'text-align': 'center',
+      'font-size': '14px',
+      padding: '12px 14px',
+      'border-radius': '3px',
+      'vertical-align': 'middle',
+      cursor: 'pointer',
+      transition: 'color 250ms cubic-bezier(0.250, 0.460, 0.450, 0.940), background-color 250ms cubic-bezier(0.250, 0.460, 0.450, 0.940)',
+      color: fgColor,
+    }
+
+    let state = {};
+    if (type === 'outline') {
+      styles['background-color'] = 'transparent';
+      styles.border = `2px solid ${bgColor}`;
+      styles.color = bgColor;
+      state = {
+        'background-color': bgColor,
+        color: fgColor
+      }
+    } else {
+      styles.border = 0;
+      styles['background-color'] = bgColor;
+      state = {
+        'background-color': `color(${bgColor} blackness(20%))`,
+        color: '#fff' //TODO: pass this in?
+      }
+    }
+
     styles['&:hover'] = state;
     styles['&:active, &.active'] = state;
     styles['&:focus'] = state;
+
     return styles;
   };
 };

--- a/styles/mixins/spacing.js
+++ b/styles/mixins/spacing.js
@@ -18,6 +18,9 @@ module.exports = function (config) {
     if (prop && position && size) {
       return spacingMixin(prop, position, size);
     }
+    if (prop) {
+      throw new Error('usage: @mixin spacing property, position, size');
+    }
     const styles = {};
     const properties = ['padding', 'margin'];
     const positions = ['top', 'left', 'right', 'bottom'];


### PR DESCRIPTION
Why is this pull request necessary:

1. make button mixin more reusable
2. single class for applying button styles
3. naming consistency (more verbose btn vs button)

Changes proposed in this pull request:

- change `.btn .btn-primary` to `.button`
- change `.btn .btn-primary-outline` to `.button-outline`
- removed secondary button (projects can add if they need)

Demo: https://firstandthird.github.io/clientkit/buttons/

Notify or mention any users: @mturnwall @dawnerd @chrisopedia 

