### PR TITLE
Add !important to hide class

### DIFF
--- a/styles/helpers/utils.css
+++ b/styles/helpers/utils.css
@@ -23,7 +23,7 @@
 }
 
 .hide {
-  display: none;
+  display: none !important;
 }
 
 @mixin hide;


### PR DESCRIPTION
Not sure if this is the best way, but the hide class is useless if there's already a display on the element.

Was thinking that maybe all of the hide/show classes be `!important` to make sure they do as they say?

Obviously, this PR doesn't solve for that as it's mainly a continuation of our discussion.

In my case, the show/hide helpers tied to breakpoints would work, but I can see this being an issue elsewhere.