### PR TITLE
added requirement to add a screenshot of docs in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@ Changes proposed in this pull request:
 -
 -
 
+Screenshot of docs:
+
 Notify or mention any users:
 
 Fixes: #<issue number>


### PR DESCRIPTION
Why is this pull request necessary:

1. makes it easier to see what the output of the change looks like

@firstandthird/developers 
