### PR TITLE
Update to fix the heading sizes, add in a new one

### DIFF
--- a/conf/default-vars.yaml
+++ b/conf/default-vars.yaml
@@ -29,10 +29,12 @@ vars:
     2-mobile-size: 25px
     3-size: 25px
     3-mobile-size: 20px
-    4-size: 16px
-    4-mobile-size: 14px
-    5-size: 14px
+    4-size: 20px
+    4-mobile-size: 16px
+    5-size: 16px
     5-mobile-size: 14px
+    6-size: 14px
+    6-mobile-size: 12px
 
   stretch-spacing: 2px
 

--- a/styles/helpers/headings.css
+++ b/styles/helpers/headings.css
@@ -8,7 +8,7 @@ title: Headings
 <div class="heading-3">Heading 3</div>
 <div class="heading-4">Heading 4</div>
 <div class="heading-5">Heading 5</div>
-<div class="heading-6">Heading 5</div>
+<div class="heading-6">Heading 6</div>
 ```
  */
 
@@ -30,4 +30,7 @@ title: Headings
 
 .heading-5 {
   @mixin heading var(--heading-5-size), var(--heading-5-mobile-size);
+}
+.heading-6 {
+  @mixin heading var(--heading-6-size), var(--heading-6-mobile-size);
 }


### PR DESCRIPTION
Why is this pull request necessary:

1. because there is a huge gap in the different sizes of headers

Changes proposed in this pull request:

- add in h6
- change h4 to use 20px
- change h5 to use 16px

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18223356/d3cd2896-7169-11e6-98ae-7271d37d2945.png)