### PR TITLE
Create color helpers for text

### DIFF
--- a/styles/helpers/typography.css
+++ b/styles/helpers/typography.css
@@ -88,7 +88,6 @@ title: Transform
   text-transform: capitalize;
 }
 
-
 /*---
 section: Typography
 title: Weight
@@ -154,11 +153,24 @@ title: Colors
 
 ```example:html
 <div style="background: #000" class="heading--light">Light Text</div>
+<p class="text-color-body">Some Text</p>
+<p class="text-color-heading">Some Text</p>
+<p style="background: #000" class="text-color-light">Some Text</p>
 ```
 */
 .heading--light {
   color: var(--color-heading-light);
 }
+.text-color-body {
+  color: var(--color-body);
+}
+.text-color-heading {
+  color: var(--color-heading);
+}
+.text-color-light {
+  color: var(--color-heading-light);
+}
+
 
 /*---
 section: Typography


### PR DESCRIPTION
Why is this pull request necessary:

1. so you can change colors of text when you need to

Changes proposed in this pull request:

- adds in the docs
- prefixes the requested helper names with `text-` so its clear its just the color, so you can add in `bg-` for background colors later

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18223392/10f29700-716b-11e6-8ef8-16746d13dab7.png)