### PR TITLE
Create triangle mixin and helper

### DIFF
--- a/styles/helpers/index.css
+++ b/styles/helpers/index.css
@@ -13,6 +13,7 @@ Here live helpers
 @import 'headings.css';
 @import 'links.css';
 @import 'spacing.css';
+@import 'triangle.css';
 
 @import 'buttons.css';
 @import 'lists.css';

--- a/styles/helpers/triangle.css
+++ b/styles/helpers/triangle.css
@@ -1,0 +1,25 @@
+/*---
+section: Helpers
+title: Triangle
+---
+
+```example:html
+<b class="triangle-up"></b>
+<b class="triangle-right"></b>
+<b class="triangle-down"></b>
+<b class="triangle-left"></b>
+```
+*/
+
+.triangle-up {
+@mixin triangle 10px, up;
+}
+.triangle-right {
+@mixin triangle 10px, right;
+}
+.triangle-down {
+@mixin triangle 10px;
+}
+.triangle-left {
+@mixin triangle 10px, left;
+}

--- a/styles/mixins/triangle.js
+++ b/styles/mixins/triangle.js
@@ -1,0 +1,48 @@
+'use strict';
+
+module.exports = function( config ) {
+  return function( mixin, size, direction ) {
+    if ( ! size ) {
+      size = '4px';
+    }
+    let borders;
+    const styles = {
+      'display' : 'inline-block',
+      'width' : 0,
+      'height' : 0,
+      'vertical-align' : 'middle',
+      'content' : '""'
+    };
+
+    if ( ! direction || 'down' === direction ) {
+      borders = {
+        'border-top' : size + ' solid',
+        'border-right' : size + ' solid transparent',
+        'border-left' : size + ' solid transparent'
+      };
+    }
+    if ( 'up' === direction ) {
+      borders = {
+        'border-bottom' : size + ' solid',
+        'border-right' : size + ' solid transparent',
+        'border-left' : size + ' solid transparent'
+      };
+    }
+    if ( 'right' === direction ) {
+      borders = {
+        'border-left' : size + ' solid',
+        'border-top' : size + ' solid transparent',
+        'border-bottom' : size + ' solid transparent'
+      };
+    }
+    if ( 'left' === direction ) {
+      borders = {
+        'border-right' : size + ' solid',
+        'border-top' : size + ' solid transparent',
+        'border-bottom' : size + ' solid transparent'
+      };
+    }
+
+    return Object.assign( styles, borders );
+  };
+};


### PR DESCRIPTION
Why is this pull request necessary:

1. we use triangles for everything
2. can be used for dropdown toggles

Changes proposed in this pull request:

- create mixin as js for directional logic
- create helper to showcase
- create mdcss

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18227686/f3e11d22-71e1-11e6-9ceb-23bfa50466e0.png)