### PR TITLE
Create default style helper for <hr />

### DIFF
--- a/conf/default-vars.yaml
+++ b/conf/default-vars.yaml
@@ -50,6 +50,11 @@ vars:
     size: 1px
     radius: 3px
 
+  hr:
+    max-width: 3.5em
+    height: 3px
+    color: '{{color.body}}'
+
   #messages
   message:
     border-radius: 2px

--- a/styles/helpers/typography.css
+++ b/styles/helpers/typography.css
@@ -185,3 +185,29 @@ title: Stretch
 .text-stretch {
   letter-spacing: var(--stretch-spacing);
 }
+
+
+/*---
+section: Typography
+title: hr
+---
+
+#### Variables
+```
+  hr-max-width: 3.5em
+  hr-height: 3px
+  hr-color: #333
+```
+
+```example:html
+<hr />
+```
+*/
+hr {
+	width: 100%;
+	max-width: var(--hr-max-width);
+	height: var(--hr-height);
+	background-color: var(--hr-color);
+	margin: 0;
+	border: 0;
+}


### PR DESCRIPTION
Why is this pull request necessary:

1. we use the `<hr />` on Women In the Workplace
2. no real default set for `<hr />`, this provides it
3. allows user controllable styling

Changes proposed in this pull request:

- add in 3 new variables for styling `<hr />`
- create the mdcss docs
- add helper to the typography.css, since its a typographical element

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18257285/f467e4ca-7375-11e6-876e-384e551cf56b.png)

Notify or mention any users: @jgallen23 