### PR TITLE
Create a text color mixin

### DIFF
--- a/conf/default-colors.yaml
+++ b/conf/default-colors.yaml
@@ -25,3 +25,4 @@ color:
   message-info: '#f0f0f0'
   message-success: '#dff0d8'
   message-error: '#f2dede'
+  text-color-error: 'red'

--- a/styles/helpers/colors.css
+++ b/styles/helpers/colors.css
@@ -3,3 +3,4 @@ body {
 }
 
 @mixin bg-colors;
+@mixin text-colors;

--- a/styles/mixins/text-colors.js
+++ b/styles/mixins/text-colors.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function (config) {
+  return function (mixin) {
+    const styles = {};
+    const isWhitelisted = color => color.startsWith('text-color-');
+    const colors = Object.keys(config.color);
+    const getColorObject = color => ({ 'color': config.color[color] });
+
+    colors.forEach(color => {
+      if (isWhitelisted(color)) {
+        styles[`.text-${color.replace('text-color-', '')}`] = getColorObject(color);
+      }
+    });
+
+    return styles;
+  };
+};


### PR DESCRIPTION
Why is this pull request necessary:

1. allows us to create a variable for any colors for text to stay brand consistent, same as we can do with `bg-{{ variable }}`.
2. solves several use cases in women in workplace where i'd be writing 1 line of code for color

Changes proposed in this pull request:

- essentially copying the `bg-colors.js` and using it for `text-colors.js`
- adds in the text-color helper to use new mixin
- adds in new variable to showcase the use

Screenshot of docs:

Notify or mention any users: @jgallen23 