### PR TITLE
update postcss-mixins, make mixins/*.css global

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "postcss-font-magician": "^1.4.0",
     "postcss-import": "^8.1.2",
     "postcss-inline-svg": "^2.0.1",
-    "postcss-mixins": "^4.0.2",
+    "postcss-mixins": "5.2.0",
     "postcss-svgo": "^2.1.3",
     "postcss-triangle": "^1.0.1",
     "require-all": "^2.0.0",

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -68,6 +68,19 @@ class CssTask {
       this.cssVars[`breakpoint-${breakpoint}`] = width;
       this.customMedia[breakpoint] = mediaquery;
     });
+    // load mixins:
+    const globalMixins = require('require-all')({
+      dirname: path.join(__dirname, '..', 'styles', 'mixins'),
+      resolve: m => m(config, postcss)
+    });
+    if (pathExists.sync(path.join(config.core.assetPath, 'mixins'))) {
+      const localMixins = require('require-all')({
+        dirname: path.join(config.core.assetPath, 'mixins'),
+        resolve: m => m(config, postcss)
+      });
+      Object.assign(globalMixins, localMixins);
+    }
+    this.mixins = globalMixins;
   }
 
   performTask(input, callback, outputName) {
@@ -80,7 +93,8 @@ class CssTask {
         ]
       }),
       cssmixins({
-        mixinsDir: path.resolve(__dirname, '../styles/mixins')
+        mixins: this.mixins,
+        mixinsFiles: path.resolve(__dirname, '../styles/mixins/*.css')
       }),
       inlinesvg(),
       svgo(),

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -68,19 +68,6 @@ class CssTask {
       this.cssVars[`breakpoint-${breakpoint}`] = width;
       this.customMedia[breakpoint] = mediaquery;
     });
-    // load mixins:
-    const globalMixins = require('require-all')({
-      dirname: path.join(__dirname, '..', 'styles', 'mixins'),
-      resolve: m => m(config, postcss)
-    });
-    if (pathExists.sync(path.join(config.core.assetPath, 'mixins'))) {
-      const localMixins = require('require-all')({
-        dirname: path.join(config.core.assetPath, 'mixins'),
-        resolve: m => m(config, postcss)
-      });
-      Object.assign(globalMixins, localMixins);
-    }
-    this.mixins = globalMixins;
   }
 
   performTask(input, callback, outputName) {
@@ -93,7 +80,7 @@ class CssTask {
         ]
       }),
       cssmixins({
-        mixins: this.mixins
+        mixinsDir: path.resolve(__dirname, '../styles/mixins')
       }),
       inlinesvg(),
       svgo(),


### PR DESCRIPTION
Why is this pull request necessary:

1. Auto expose mixins/*.css to all files

Changes proposed in this pull request:

- updated postcss-mixins lib
- change to use mixinFiles to load up css files

Notify or mention any users: @dawnerd 


