### PR TITLE
Create mobile menu helper/mixin

### DIFF
--- a/styles/helpers/index.css
+++ b/styles/helpers/index.css
@@ -29,3 +29,4 @@ Here live helpers
 @import 'messages.css';
 @import 'borders.css';
 @import 'typography.css';
+@import 'mobile-menu';

--- a/styles/helpers/mobile-menu.css
+++ b/styles/helpers/mobile-menu.css
@@ -1,0 +1,23 @@
+/*---
+section: Helpers
+title: Mobile Menu
+---
+```example:html
+<div class="mobile-menu">
+  <input id="header-menu" class="menu-btn" type="checkbox" />
+  <label for="header-menu"></label>
+  <div class="menu-container text-right">
+    <nav class="menu-header-container">
+      <a href="">Menu 1</a>
+      <a href="">Menu 2</a>
+      <a href="">Menu 3</a>
+      <a href="">Menu 4</a>
+    </nav>
+  </div>
+</div>
+```
+*/
+.mobile-menu {
+  @mixin mobile-menu var(--color-primary) var(--color-white);
+}
+

--- a/styles/mixins/index.css
+++ b/styles/mixins/index.css
@@ -11,3 +11,4 @@ Mixins yo!
 @import 'row-carousel.css';
 @import 'link.css';
 @import 'input.css';
+@import 'mobile-menu.css';

--- a/styles/mixins/mobile-menu.css
+++ b/styles/mixins/mobile-menu.css
@@ -1,0 +1,82 @@
+/*---
+section: Mixins
+title: Mobile Menu
+---
+
+```
+@mixin mobile-menu $menuColor, $closeColor
+```
+*/
+
+
+
+@define-mixin mobile-menu $menuColor, $closeColor {
+  & .menu-btn {
+    position: absolute;
+    visibility: hidden;
+    width: 28px;
+    height: 28px;
+    margin-left: -999em;
+    -webkit-appearance: none;
+
+    & + label {
+      display: none;
+      position: relative;
+      z-index: 1000;
+      float: right;
+      margin: 0;
+      transition: color .3s ease-in-out;
+      cursor: pointer;
+      user-select:none;
+
+      @media (--tablet) {
+        display: block;
+      }
+
+      &::after {
+        display: inline-block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        vertical-align: middle;
+        border: 0;
+        padding: 0;
+        background: transparent;
+        color: $menuColor;
+        font-family: Arial;
+        font-size: 36px;
+        line-height: 1;
+        content: '\2261';
+      }
+    }
+    &:checked {
+      & + label::after {
+        border: 1px solid $closeColor;
+        border-radius: 50%;
+        padding: 2px 8px 0;
+        color: $closeColor;
+        content: '\00d7';
+      }
+      & ~ .menu-container {
+        right: 63%;
+      }
+    }
+    @media (--tablet) {
+      & ~ .menu-container {
+        position: fixed;
+        top: 0;
+        right: -65%;
+        z-index: 10;
+        width: 60%;
+        height: 100%;
+        box-shadow: -3px 0 3px 0 rgba(0, 0, 0, 0.25);
+        padding: var(--spacing-sm) 0 var(--spacing-lg);
+        padding-top: 80px;
+        background-color: $menuColor;
+        transform: translate3d(103%, 0, 0);
+        transition: transform 250ms cubic-bezier(0.35, 0.97, 0.57, 0.99),
+                    right 250ms cubic-bezier(0.35, 0.97, 0.57, 0.99) 300ms;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Why is this pull request necessary:

1. we use it all the time
2. fb-inspired and simms-man

Changes proposed in this pull request:

- create mixin that passes in 2 colors
- add in the helper that uses mixin

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18406691/f4954d2e-76b4-11e6-8982-5b59fb952fa3.png)


Notify or mention any users: @jgallen23 
