### PR TITLE
Browserify shim

### DIFF
--- a/conf/default-core.yaml
+++ b/conf/default-core.yaml
@@ -29,3 +29,6 @@ autoprefixer:
     - 'iOS 8'
     - 'iOS 9'
 
+scriptConfig:
+  shim: false
+  babelIgnore: null

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
+    "browserify-shim": "^3.8.12",
     "bytesize": "^0.2.0",
     "chokidar": "^1.6.0",
     "confi": "^2.3.0",

--- a/tasks/script.js
+++ b/tasks/script.js
@@ -35,7 +35,10 @@ module.exports = function(conf, base, outputName, input) {
     }
     const end = new Date().getTime();
     const duration = (end - start) / 1000;
-    bytesize.fileSize(output, true, function(err, size) {
+    bytesize.fileSize(output, true, (err, size) => {
+      if (err) {
+        throw err;
+      }
       log(`Processed: ${input} → ${output} (${size}) in ${duration} sec, `);
     });
   });
@@ -59,12 +62,13 @@ module.exports = function(conf, base, outputName, input) {
   if (conf.core.minify) {
     currentTransform = currentTransform.transform(uglifyify, { global: true });
   }
+
   currentTransform
-  .bundle()
-  .on('error', function (err) {
-    log(['error'], err);
-    this.emit('end');
-  })
-  .pipe(exorcist(`${output}.map`))
-  .pipe(fileStream);
+    .bundle()
+    .on('error', function (err) {
+      log(['error'], err);
+      this.emit('end');
+    })
+    .pipe(exorcist(`${output}.map`))
+    .pipe(fileStream);
 };

--- a/tasks/script.js
+++ b/tasks/script.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const Browserify = require('browserify');
 const babelify = require('babelify');
+const shim = require('browserify-shim');
 const exorcist = require('exorcist');
 const bes2015 = require('babel-preset-es2015');
 const uglifyify = require('uglifyify');
@@ -44,7 +45,17 @@ module.exports = function(conf, base, outputName, input) {
     debug: true
   });
 
-  let currentTransform = b.transform(babelify, { global: conf.core.globalBabel, presets: [bes2015], plugins: [] });
+  if (conf.scriptConfig.shim) {
+    b.transform(shim);
+  }
+
+  let currentTransform = b.transform(babelify, {
+    global: conf.core.globalBabel,
+    presets: [bes2015],
+    plugins: [],
+    ignore: conf.scriptConfig.babelIgnore
+  });
+
   if (conf.core.minify) {
     currentTransform = currentTransform.transform(uglifyify, { global: true });
   }


### PR DESCRIPTION
Why is this pull request necessary:

1. To let us include libraries from bower and libraries that don't use require/import
2. To let us skip certain files from going through babel (like jquery)

Changes proposed in this pull request:

- Added an option for `scriptConfig.shim` to enable that transform
- Added an option for `scriptConfig.babelIgnore` to skip files from going through babel
- fix some linting issues in script.js

Screenshot of docs: n/a

Notify or mention any users: @dawnerd 

Here is the plugin docs: https://github.com/thlorenz/browserify-shim
