### PR TITLE
Create; custom media queries for each breakpoint

### DIFF
--- a/styles/helpers/custom-media-queries.css
+++ b/styles/helpers/custom-media-queries.css
@@ -1,0 +1,69 @@
+/*---
+section: Helpers
+title: Custom Media Queries
+---
+
+#### Usage
+
+For all of the breakpoints there are 3 options.  An `up` to target from a min-width of a particular breakpoint and up.  A `down` to target from a max-width of a particular breakpoint and down.  And an `only` to target from a min-width of a breakpoint to the max-width of that same breakpoint.
+
+#### Up
+
+```example:css
+@media (--tablet-up) {
+  body {
+    background-color: red;
+  }
+}
+```
+
+will compile to:
+
+```example:css
+@media (min-width: 768px) {
+  body {
+    background-color: red;
+  }
+}
+```
+
+#### Down
+
+```example:css
+@media (--tablet-down) {
+  body {
+    background-color: green;
+  }
+}
+```
+
+will compile to:
+
+```example:css
+@media (max-width: 1023px) {
+  body {
+    background-color: red;
+  }
+}
+```
+
+#### Only
+
+```example:css
+@media (--tablet-only) {
+  body {
+    background-color: blue;
+  }
+}
+```
+
+will compile to:
+
+```example:css
+@media (min-width: 768px) and (max-width: 1023px) {
+  body {
+    background-color: red;
+  }
+}
+```
+*/

--- a/styles/helpers/index.css
+++ b/styles/helpers/index.css
@@ -4,6 +4,7 @@ section: Helpers
 Here live helpers
 */
 @import 'reset.css';
+@import 'custom-media-queries.css';
 @import 'mediaqueries.css';
 @import 'box-sizing.css';
 @import 'colors.css';

--- a/styles/helpers/mediaqueries.css
+++ b/styles/helpers/mediaqueries.css
@@ -1,3 +1,19 @@
 :root {
+  @custom-media --desktop-wide-up (min-width: 1440px);
+  @custom-media --desktop-wide-down (max-width: 100vw);
+  @custom-media --desktop-wide-only (min-width: 1440px) and (max-width: 100vw);
+
+  @custom-media --desktop-up (min-width: 1024px);
+  @custom-media --desktop-down (max-width: 1439px);
+  @custom-media --desktop-only (min-width: 1024px) and (max-width: 1439px);
+
+  @custom-media --tablet-up (min-width: 768px);
+  @custom-media --tablet-down (max-width: 1023px);
+  @custom-media --tablet-only (min-width: 768px) and (max-width: 1023px);
+
+  @custom-media --mobile-up (min-width: 320px);
+  @custom-media --mobile-down (max-width: 767px);
+  @custom-media --mobile-only (min-width: 320px) and (max-width: 767px);
+
   @custom-media --tablet (min-width: 768px);
 }


### PR DESCRIPTION
Why is this pull request necessary:

So we can target breakpoints regardless of mobile first or desktop first approach

Changes proposed in this pull request:

- There is nothing that is actually output since these are just media queries in the `:root{}` selector, so I've created docs to show how to use them.
- I feel like there is probably a better way to do this using the JS mixin style but after exploring some options, I couldn't figure out how to accomplish it and this seems to be the simplest approach by just adding in the `:root{}` media queries.  I tested trying to use variables in the custom media queries and that didn't work either.  Don't know if thats a limitation of PostCSS or what.

I looked at using [postcss/postcss-media-minmax](https://github.com/postcss/postcss-media-minmax), but seemed like overkill.  Same goes for [postcss/postcss-custom-media](https://github.com/postcss/postcss-custom-media)

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18611853/1027df54-7cfd-11e6-8029-0bf3d845c695.png)

Notify or mention any users: @jgallen23 