### PR TITLE
Update tab mixin to pass in js option

### DIFF
--- a/styles/helpers/tabs.css
+++ b/styles/helpers/tabs.css
@@ -3,11 +3,10 @@ section: Helpers
 title: Tabs
 ---
 
+### No JS
+
 ```example:html
-
 <div class="tabs">
-
-  <!-- active tab on page load gets checked attribute -->
   <input type="radio" id="tab1" name="tabGroup1" class="tab" checked>
   <label for="tab1">Short</label>
 
@@ -17,7 +16,45 @@ title: Tabs
   <input type="radio" id="tab3" name="tabGroup1" class="tab">
   <label for="tab3">Long</label>
 
+  <a href="http://example.com/" target="_blank">External URL</a>
+
   <div class="tab-content">
+    <h3>Short Section</h3>
+    <p>Praesent nonummy mi in odio. Nullam accumsan lorem in dui. Vestibulum turpis sem, aliquet eget, lobortis pellentesque, rutrum eu, nisl. Nullam accumsan lorem in dui. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</p>
+  </div>
+
+  <div class="tab-content">
+    <h3>Medium Section</h3>
+    <p>Praesent nonummy mi in odio. Nullam accumsan lorem in dui. Vestibulum turpis sem, aliquet eget, lobortis pellentesque, rutrum eu, nisl. Nullam accumsan lorem in dui. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</p>
+
+    <p>In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Morbi mattis ullamcorper velit. Pellentesque posuere. Etiam ut purus mattis mauris sodales aliquam. Praesent nec nisl a purus blandit viverra.</p>
+  </div>
+
+  <div class="tab-content">
+    <h3>Long Section</h3>
+    <p>Praesent nonummy mi in odio. Nullam accumsan lorem in dui. Vestibulum turpis sem, aliquet eget, lobortis pellentesque, rutrum eu, nisl. Nullam accumsan lorem in dui. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</p>
+
+    <p>In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Morbi mattis ullamcorper velit. Pellentesque posuere. Etiam ut purus mattis mauris sodales aliquam. Praesent nec nisl a purus blandit viverra.</p>
+
+    <p>Praesent nonummy mi in odio. Nullam accumsan lorem in dui. Vestibulum turpis sem, aliquet eget, lobortis pellentesque, rutrum eu, nisl. Nullam accumsan lorem in dui. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</p>
+
+    <p>In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Morbi mattis ullamcorper velit. Pellentesque posuere. Etiam ut purus mattis mauris sodales aliquam. Praesent nec nisl a purus blandit viverra.</p>
+  </div>
+
+</div>
+```
+
+### JS
+
+```example:html
+<div class="tabs-js">
+
+  <a class="tab selected" href="">Tab 1</a>
+  <a class="tab" href="">Tab 2</a>
+  <a class="tab" href="">Tab 3</a>
+  <a class="tab" href="http://example.com/" target="_blank">External URL</a>
+
+  <div class="tab-content selected">
     <h3>Short Section</h3>
     <p>Praesent nonummy mi in odio. Nullam accumsan lorem in dui. Vestibulum turpis sem, aliquet eget, lobortis pellentesque, rutrum eu, nisl. Nullam accumsan lorem in dui. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.</p>
   </div>
@@ -45,4 +82,7 @@ title: Tabs
 */
 .tabs {
   @mixin tabs 5, 6px;
+}
+.tabs-js {
+  @mixin tabs 5, 6px, js;
 }

--- a/styles/mixins/tabs.js
+++ b/styles/mixins/tabs.js
@@ -1,29 +1,48 @@
 'use strict';
 module.exports = function () {
-  return function (mixin, number, borderRadius) {
-    const styles = {
-      display: 'flex',
-      'flex-wrap': 'wrap',
-      'max-width': '100%',
-      position: 'relative',
-      'list-style': 'none',
-      'border-radius': borderRadius,
-      '& .tab': {
+  return function (mixin, number, borderRadius, style) {
+    const selectedState = {
+      'cursor': 'default'
+    };
+    const firstChild = {
+      'border-top-right-radius': '0',
+      'border-bottom-right-radius': '0'
+    };
+    const allChildren = {
+      'border-radius': '0'
+    };
+    const lastChild = {
+      'border-top-left-radius': '0',
+      'border-bottom-left-radius': '0'
+    };
+    let tabStyle;
+    if ( 'js' === style ) {
+      tabStyle = {
+        display: 'block',
+        'box-sizing': 'border-box',
+        'flex-grow': '3',
+        'border-radius': `${borderRadius} ${borderRadius} 0 0`,
+        'text-decoration': 'none',
+        cursor: 'pointer',
+        'user-select': 'none',
+        '&:first-of-type:not(:last-of-type)': firstChild,
+        '&:not(:first-of-type):not(:last-of-type)': allChildren,
+        '&:last-of-type:not(:first-of-type)': lastChild,
+        '&.selected': selectedState,
+        '&-content': {
+          'display': 'none',
+          '&.selected': {
+            'display': 'block'
+          }
+        }
+      };
+    } else {
+      tabStyle = {
         display: 'none',
-        '&:first-of-type:not(:last-of-type) + label': {
-          'border-top-right-radius': '0',
-          'border-bottom-right-radius': '0'
-        },
-        '&:not(:first-of-type):not(:last-of-type) + label': {
-          'border-radius': '0'
-        },
-        '&:last-of-type:not(:first-of-type) + label': {
-          'border-top-left-radius': '0',
-          'border-bottom-left-radius': '0'
-        },
-        '&:checked + label': {
-          cursor: 'default'
-        },
+        '&:first-of-type:not(:last-of-type) + label': firstChild,
+        '&:not(:first-of-type):not(:last-of-type) + label': allChildren,
+        '&:last-of-type:not(:first-of-type) + label': lastChild,
+        '&:checked + label': selectedState,
         '& + label': {
           'box-sizing': 'border-box',
           display: 'block',
@@ -42,18 +61,29 @@ module.exports = function () {
           opacity: 0,
           transform: 'translateY(-3px)'
         }
-      }
-    };
-    const tabStyle = {
+      };
+    }
+    const styles = {
+      display: 'flex',
+      'flex-wrap': 'wrap',
+      'max-width': '100%',
       position: 'relative',
-      top: '0',
-      'z-index': '100',
-      opacity: '1',
-      transform: 'translateY(0px)',
-      transition: '0.5s opacity ease-in, 0.8s transform ease'
+      'list-style': 'none',
+      'border-radius': borderRadius,
+      '& .tab': tabStyle
     };
-    for (let i = 1; i <= number; i++) {
-      styles[`& .tab:checked:nth-of-type(${i}) ~ .tab-content:nth-of-type(${i})`] = tabStyle;
+    if ( 'js' !== style ) {
+      const tabContentStyle = {
+        position: 'relative',
+        top: '0',
+        'z-index': '100',
+        opacity: '1',
+        transform: 'translateY(0px)',
+        transition: '0.5s opacity ease-in, 0.8s transform ease'
+      };
+      for (let i = 1; i <= number; i++) {
+        styles[`& .tab:checked:nth-of-type(${i}) ~ .tab-content:nth-of-type(${i})`] = tabContentStyle;
+      }
     }
 
     return styles;


### PR DESCRIPTION
Why is this pull request necessary:

1. requested feature
2. allows for a JS option for tabs

Changes proposed in this pull request:

- convert the mixin to handle a 'js' flag that chnages styles accordingly
- update helpers to provide both options now
- update docs to show both options

Screenshot of docs:

![image](https://cloud.githubusercontent.com/assets/5769156/18612940/c31d077a-7d1f-11e6-9ae3-9cd2defe6068.png)