### PR TITLE
Flex grid fixes

### DIFF
--- a/styles/mixins/flex-grid.js
+++ b/styles/mixins/flex-grid.js
@@ -52,7 +52,7 @@ module.exports = function (config) {
       const block = styles[breakpoint];
 
       // Layout
-      let layoutSelector = '.flex-row';
+      let layoutSelector = `.${layoutPrefix}`;
       for (const layout in layouts) {
         let selector = `.${layoutPrefix}-${layout}`;
         layoutSelector += `,\n${selector}`;

--- a/styles/mixins/flex-grid.js
+++ b/styles/mixins/flex-grid.js
@@ -118,7 +118,9 @@ module.exports = function (config) {
 
       for (let i = 1; i <= cols; i++) {
         block[`.${prefix}-${i}`] = {
-          'flex-basis': `${(100 / (12 / i))}%`
+          'flex-basis': `${(100 / (12 / i))}%`,
+          'padding-left': '15px',
+          'padding-right': '15px'
         };
 
         block[`.${prefix}-offset-${i}`] = {


### PR DESCRIPTION
Why is this pull request necessary:

1. Because we don't have paddings (as we do on the normal grid).
2. Because we don't have a way to say `flex-md-row` right now.

Changes proposed in this pull request:

- Add paddings to all columns
- Add flex-row selectors for breakpoints.