### PR TITLE
Adds tablet breakpoint to fix font sizes in mobile-first

### DIFF
--- a/styles/helpers/typography.css
+++ b/styles/helpers/typography.css
@@ -140,6 +140,10 @@ title: Size
   @media(--mobile) {
     font-size: var(--font-mobile-size-large);
   }
+
+  @media(--tablet) {
+    font-size: var(--font-size-large);
+  }
 }
 
 .font-small {
@@ -148,6 +152,10 @@ title: Size
   @media(--mobile) {
     font-size: var(--font-mobile-size-small);
   }
+
+  @media(--tablet) {
+    font-size: var(--font-size-small);
+  }
 }
 
 .font-body {
@@ -155,6 +163,10 @@ title: Size
 
   @media(--mobile) {
     font-size: var(--font-mobile-size-body);
+  }
+
+  @media(--tablet) {
+    font-size: var(--font-size-body);
   }
 }
 


### PR DESCRIPTION
Simple fix. When we switched to css mixins old functionality broke. Added a tablet breakpoint that'll reset the size back when in mobile first and shouldn't do anything on desktop first.
