### PR TITLE
Upgrading taskkit

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,15 @@ process.env.TASKKIT_PREFIX = 'clientkit';
 process.env.TASKKIT_BASECONFIG = path.join(__dirname, 'conf');
 process.env.TASKKIT_CKDIR = __dirname;
 const task = process.argv[2] || 'default';
-process.on('unhandledRejection', r => console.log(r)); // eslint-disable-line no-console
-main(task);
+
+
+const run = async function() {
+  try {
+    await main(task);
+  } catch (e) {
+    console.log(e);
+    process.exit(1);
+  }
+};
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       }
     },
     "confi": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/confi/-/confi-9.4.0.tgz",
-      "integrity": "sha512-pt/1H2K03ggf5klJFXW4NAOscOPVh57fv34L4LRUVk9m3uCY5YFFlbabvt+bWfjpoqNmT35kTjOzqA4Sna2c3Q==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/confi/-/confi-9.5.0.tgz",
+      "integrity": "sha512-s4H6cnt4N0rU1KZFOt8EzWlZoAiX7y2PwPVSo1Q+urGry4EOS2uCk2tmts++z+QuF2hFUfXg3ODUoz5xKeXPig==",
       "requires": {
         "aug": "^2.0.0",
         "envload": "^0.1.0",
@@ -4779,7 +4779,7 @@
     },
     "joi": {
       "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "resolved": "http://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
         "hoek": "2.x.x",
@@ -11090,7 +11090,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "requires": {
             "ansi-styles": "~1.0.0",
@@ -12682,9 +12682,9 @@
       }
     },
     "taskkit": {
-      "version": "3.0.0-7",
-      "resolved": "https://registry.npmjs.org/taskkit/-/taskkit-3.0.0-7.tgz",
-      "integrity": "sha512-p/TLN5eEYEzo8m3bqC5m66SPqkCOqD10HTWZB3HBB8eG4E4f2xhGgb5ZqvKLW5yvzhEVj1YneZwGDWiObnEnVQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/taskkit/-/taskkit-3.1.0.tgz",
+      "integrity": "sha512-II1VV49p1A0qwmZl4Smr6JrPyeu2tyh6LuJofCY0vuPOFDcdN+p9to0jupIvEiUFOYDyg6g+7aXluKSrflOyRg==",
       "requires": {
         "async": "^2.4.1",
         "confi": "^9.0.1",
@@ -12760,7 +12760,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
             "camelcase": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "clientkit-css": "^2.3.0",
     "clientkit-styleguide": "^1.1.1",
-    "taskkit": "^3.0.0-7",
+    "taskkit": "^3.1.0",
     "taskkit-analyze": "^1.0.0",
     "taskkit-clean": "^1.1.0",
     "taskkit-eslint": "^1.1.3",


### PR DESCRIPTION
Why is this pull request necessary:

1. To make `crashOnError` actually work.

Changes proposed in this pull request:

- Upgrade taskkit to `3.1.0`