### PR TITLE
only hash if hash.disabled !== true

### DIFF
--- a/webpack/configs/svg/index.js
+++ b/webpack/configs/svg/index.js
@@ -51,7 +51,7 @@ module.exports = config => {
 
             task.execute().then(() => {
               // Transform to hash
-              if (paths.isProduction) {
+              if (paths.isProduction && enableHashing) {
                 outputFiles.forEach(file => {
                   const content = fs.readFileSync(file, 'utf8');
                   const hash = crypto.createHash('md5').update(content).digest('hex');


### PR DESCRIPTION
Why is this pull request necessary:

1. there is a bug so that hash.disabled does not apply to .svg files like it does to js/css
2. 
3.

Changes proposed in this pull request:

- make .svg look at hash.disabled before hashing svg file names
-
-

Notify or mention any users:

Fixes: #<issue number>
